### PR TITLE
feat(skills): add CodeKit skill and MCP documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ dist/
 issues_image
 .debug-extensions/
 designs/
+
+.codegraph/
+.mcp.json
+.claude/

--- a/README.md
+++ b/README.md
@@ -29,11 +29,45 @@ CodeKit 内置独立的串口监视器面板，不再依赖 VS Code 终端作为
 
 ## MCP Server
 
-从当前版本开始，CodeKit 内置了一个可选的 MCP Server，供其他 agent 工具或 IDE 通过 MCP 调用插件能力。
+从当前版本开始，CodeKit 内置了一个可选的 MCP Server，供 Claude Code、GitHub Copilot 等 agent 工具或 IDE 通过 MCP 协议调用插件能力。所有工具分为六大功能类别。
 
-- 在命令面板中执行 `Start SiFli MCP Server` 启动服务
-- 执行 `Show SiFli MCP Connection Info` 获取连接地址和 Bearer Token
-- 可通过设置 `sifli-sdk-codekit.mcp.autoStart` 让扩展激活时自动启动 MCP
-- 串口 MCP 工具包括 `sifli.serial.listPorts`、`sifli.serial.connect`、`sifli.serial.write`、`sifli.serial.read`、`sifli.serial.reset`、`sifli.serial.status` 和 `sifli.serial.disconnect`
+### 快速开始
 
-当前实现运行在 VS Code 扩展宿主内，因此外部客户端连接 MCP 时，需要本插件所在的 VS Code 实例保持运行。
+- 在扩展面板中点击 `状态` 启动服务
+- 点击 `复制连接信息` 获取连接地址和 Bearer Token
+- 可通过设置 `自动启动` 让扩展激活时自动启动 MCP
+
+### 工具概览
+
+| 类别 | 说明 |
+|------|------|
+| 📦 SDK 管理 | 列出已配置的 SDK、切换激活版本 |
+| 🔧 开发板管理 | 扫描可用开发板、选择活动板卡 |
+| 📁 项目管理 | 查看项目状态、从模板创建项目、生成 clangd 配置 |
+| 🛠 项目构建 | 编译、重新构建、清理、下载固件、打开 menuconfig |
+| 🔌 串口通信 | 串口列表、连接、读写、复位、状态查询 |
+| 📺 串口监视器 | 打开/关闭串口监视器面板 |
+| ⚙️ 自动化工作流 | 列出、查看、验证、运行工作流 |
+
+完整的工具名称、参数及使用说明请参考[进阶功能 - MCP 与 Skills](https://docs.sifli.com/projects/codekit/Feature/mcp-and-skills.html)。
+
+### 架构说明
+
+当前实现运行在 VS Code 扩展宿主内，因此外部客户端连接 MCP 时，需要本插件所在的 VS Code 实例保持运行。MCP Server 采用 Bearer Token 认证，支持固定 Token 和自动生成 Token 两种方式，确保连接安全。
+
+## Skills
+
+本仓库提供一个通用 `sifli-sdk-codekit` skill，可通过社区 `skills` CLI 安装到 Claude Code、Codex 和 GitHub Copilot。
+
+```bash
+npx skills add OpenSiFli/SiFli-SDK-CodeKit
+
+# 指定技能和目标 agent
+npx skills add OpenSiFli/SiFli-SDK-CodeKit --skill sifli-sdk-codekit -a claude-code
+npx skills add OpenSiFli/SiFli-SDK-CodeKit --skill sifli-sdk-codekit -a codex
+npx skills add OpenSiFli/SiFli-SDK-CodeKit --skill sifli-sdk-codekit -a github-copilot
+```
+
+使用前请确保 VS Code 已安装并启用 SiFli SDK CodeKit 插件，并已启动 CodeKit MCP Server。该 skill 会优先引导 agent 使用 CodeKit 提供的 SDK、开发板、项目、编译、下载、串口监视器和工作流 MCP 工具；如果当前环境无法看到 CodeKit 工具，会提示按连接文档完成配置。
+
+安装内容位于 `skills/sifli-sdk-codekit/`。

--- a/README_EN.md
+++ b/README_EN.md
@@ -2,9 +2,7 @@
   <img src="images/readme/SiFli.png" alt="SiFli SDK" title="SiFli" align="right" height="100" />
 </a>
 
-# sifli-sdk-codek**Q3: Terminal doesn't automatically enter the project folder?**
-
-- Please ensure that a subfolder named `project` exists in the root directory.- VS Code Extension
+# sifli-sdk-codekit - VS Code Extension
 
 [中文](./README.md)
 
@@ -31,11 +29,30 @@ CodeKit includes a standalone serial monitor panel and no longer depends on the 
 
 ## MCP Server
 
-CodeKit now includes an optional embedded MCP Server so other agent tools or IDEs can call extension capabilities through MCP.
+CodeKit now includes an optional embedded MCP Server so agent tools (Claude Code, GitHub Copilot, etc.) or IDEs can call extension capabilities through the MCP protocol. All tools are organized into six functional categories.
 
-- Run `Start SiFli MCP Server` from the command palette to start the server
-- Run `Show SiFli MCP Connection Info` to get the URL and Bearer token
-- Enable `sifli-sdk-codekit.mcp.autoStart` to start it automatically on activation
-- Serial MCP tools include `sifli.serial.listPorts`, `sifli.serial.connect`, `sifli.serial.write`, `sifli.serial.read`, `sifli.serial.reset`, `sifli.serial.status`, and `sifli.serial.disconnect`
+### Quick Start
 
-The current implementation runs inside the VS Code extension host, so the VS Code instance that hosts CodeKit must remain running while external clients use the MCP connection.
+- Click `Status` in the extension panel to start the server
+- Click `Copy Connection Info` to get the URL and Bearer token
+- Enable `Auto Start` in settings to start MCP automatically on extension activation
+
+### Tool Overview
+
+| Category | Description |
+|----------|-------------|
+| 📦 SDK Management | List configured SDKs, switch active version |
+| 🔧 Board Management | Scan for boards, select active board |
+| 📁 Project Management | Get project state, create from template, configure clangd |
+| 🛠 Build | Compile, rebuild, clean, download firmware, open menuconfig |
+| 🔌 Serial Communication | List ports, connect, read/write, reset, query status |
+| 📺 Serial Monitor | Open/close the serial monitor panel |
+| ⚙️ Automation Workflows | List, get, validate, run workflows |
+
+::: tip
+For complete tool names, parameters, and usage, refer to the [MCP & Skills](https://docs.sifli.com/projects/codekit/Feature/mcp-and-skills.html) documentation.
+:::
+
+### Architecture
+
+The current implementation runs inside the VS Code extension host, so the VS Code instance hosting CodeKit must remain running while external clients use the MCP connection. The MCP Server uses Bearer Token authentication and supports both fixed and auto-generated tokens for secure connections.

--- a/docs/src/Feature/README.md
+++ b/docs/src/Feature/README.md
@@ -7,6 +7,7 @@ icon: fa-solid fa-wrench
 
 - [SDK 依赖源码浏览](#sdk-依赖源码浏览)
 - [动态工作流](workflows.md)
+- [MCP 与 Skills](mcp-and-skills.md)
 
 ## SDK 依赖源码浏览
 

--- a/docs/src/Feature/mcp-and-skills.md
+++ b/docs/src/Feature/mcp-and-skills.md
@@ -1,0 +1,106 @@
+---
+title: MCP 与 Skills
+icon: fa-solid fa-plug
+order: 3
+---
+
+CodeKit 内置了 MCP Server，让 Claude Code、GitHub Copilot 等 AI 编程工具可以直接通过 MCP 协议调用插件能力，也支持通过社区 `skills` CLI 一键安装专用 Skill。
+
+## MCP Server
+
+从当前版本开始，CodeKit 内置了一个可选的 MCP Server，供外部 agent 工具或 IDE 通过 MCP 协议调用插件能力。所有工具按功能分为六大类别。
+
+### 快速开始
+
+- 在扩展面板中点击 `状态` 启动服务
+- 点击 `复制连接信息` 获取连接地址和 Bearer Token
+- 可通过设置 `自动启动` 让扩展激活时自动启动 MCP
+
+### 工具概览
+
+#### 📦 SDK 管理
+
+| 工具 | 功能说明 |
+|------|---------|
+| `sifli.sdk.list` | 列出已配置的 SiFli SDK 及当前激活的 SDK |
+| `sifli.sdk.activate` | 按路径或版本切换激活的 SDK |
+
+#### 🔧 开发板管理
+
+| 工具 | 功能说明 |
+|------|---------|
+| `sifli.board.list` | 从 SDK、自定义路径和项目中扫描可用开发板 |
+| `sifli.board.select` | 选择当前活动开发板，可选指定编译线程数 |
+
+#### 📁 项目管理
+
+| 工具 | 功能说明 |
+|------|---------|
+| `sifli.project.getState` | 获取项目、SDK、开发板、串口、监视器和工作流的综合状态 |
+| `sifli.project.listTemplates` | 列出 SDK 示例树中可创建的项目模板 |
+| `sifli.project.createFromExample` | 基于 SDK 示例模板创建新项目（支持 Git 初始化） |
+| `sifli.project.configureClangd` | 为当前活动开发板生成 clangd 配置 |
+
+#### 🛠 项目构建
+
+| 工具 | 功能说明 |
+|------|---------|
+| `sifli.build.compile` | 编译当前项目（后台任务） |
+| `sifli.build.rebuild` | 清理构建目录后重新编译 |
+| `sifli.build.clean` | 删除当前构建输出目录 |
+| `sifli.build.download` | 烧录固件到目标设备 |
+| `sifli.build.menuconfig` | 在 VS Code 终端中打开 menuconfig 配置界面 |
+
+#### 🔌 串口通信
+
+| 工具 | 功能说明 |
+|------|---------|
+| `sifli.serial.listPorts` | 列出可用串口及当前下载/日志波特率 |
+| `sifli.serial.selectPort` | 选择下载串口，可选更新下载波特率 |
+| `sifli.serial.connect` | 连接串口用于 MCP 驱动的设备交互 |
+| `sifli.serial.disconnect` | 断开当前串口 MCP 会话 |
+| `sifli.serial.write` | 向串口发送字符串或 HEX 字节数据 |
+| `sifli.serial.read` | 读取串口日志缓冲区内容 |
+| `sifli.serial.reset` | 通过 DTR/RTS 控制线发送复位脉冲 |
+| `sifli.serial.status` | 查询串口会话状态和日志条目数 |
+
+#### 📺 串口监视器
+
+| 工具 | 功能说明 |
+|------|---------|
+| `sifli.monitor.open` | 打开串口监视器面板 |
+| `sifli.monitor.close` | 关闭当前串口监视器会话 |
+
+#### ⚙️ 自动化工作流
+
+| 工具 | 功能说明 |
+|------|---------|
+| `sifli.workflow.list` | 列出工作空间或用户设置中的工作流 |
+| `sifli.workflow.get` | 获取单个工作流定义及运行时兼容性详情 |
+| `sifli.workflow.validate` | 验证工作流配置或提供的定义是否正确 |
+| `sifli.workflow.run` | 按引用运行工作流，可传入输入参数 |
+
+### 架构说明
+
+MCP Server 运行在 VS Code 扩展宿主内，因此外部客户端连接时需要本插件所在的 VS Code 实例保持运行。服务采用 Bearer Token 认证，支持固定 Token 和自动生成 Token 两种方式，确保连接安全。
+
+## Skills
+
+本仓库提供一个通用 `sifli-sdk-codekit` skill，可通过社区 `skills` CLI 安装到 Claude Code、Codex 和 GitHub Copilot。
+
+```bash
+npx skills add OpenSiFli/SiFli-SDK-CodeKit
+
+# 指定技能和目标 agent
+npx skills add OpenSiFli/SiFli-SDK-CodeKit --skill sifli-sdk-codekit -a claude-code
+npx skills add OpenSiFli/SiFli-SDK-CodeKit --skill sifli-sdk-codekit -a codex
+npx skills add OpenSiFli/SiFli-SDK-CodeKit --skill sifli-sdk-codekit -a github-copilot
+```
+
+### 使用前提
+
+- VS Code 已安装并启用 SiFli SDK CodeKit 插件
+- CodeKit MCP Server 已启动
+- 目标 agent 已按连接文档完成 MCP 配置
+
+安装后，Skill 会优先引导 agent 使用 CodeKit 提供的 MCP 工具完成 SDK、开发板、项目、编译、下载、串口监视器和工作流等操作。Skill 的完整安装文件位于仓库 `skills/sifli-sdk-codekit/` 目录下；如果当前环境无法看到 CodeKit 工具，会提示按连接文档完成配置。

--- a/skills/sifli-sdk-codekit/SKILL.md
+++ b/skills/sifli-sdk-codekit/SKILL.md
@@ -129,7 +129,7 @@ Stop and re-evaluate when you catch yourself thinking or doing any of these:
 
 ## Task Map
 
-- For MCP installation, connection info, `.mcp.json`, and Codex CLI setup, read `references/installation.md`.
+- For MCP installation, connection info, and Codex CLI setup, read `references/installation.md`.
 - For tool names, required inputs, and common operation order, read `references/tools.md`.
 - For reusable CodeKit workflows and workflow JSON shape, read `references/workflows.md`.
 - For serial/MCP/build failure handling, read `references/troubleshooting.md`.

--- a/skills/sifli-sdk-codekit/SKILL.md
+++ b/skills/sifli-sdk-codekit/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: sifli-sdk-codekit
+description: Use when the task mentions CodeKit, SiFli SDK CodeKit, the CodeKit MCP server, SiFli board/project/build/download/serial/monitor workflows, or VS Code extension-hosted SiFli tooling.
+---
+
+# CodeKit
+
+Use this skill to drive SiFli SDK CodeKit as the high-level orchestration layer for SiFli development. CodeKit runs inside the VS Code extension host and exposes MCP tools for SDK, board, project, build, serial, monitor, and workflow operations.
+
+## First Choice
+
+Prefer CodeKit-hosted tools over shell commands when the task can be expressed through the extension. Use the exact tool names exposed by the current agent environment:
+
+- SDK setup or switching: use `sifli_sdk_*`.
+- Board discovery or selection: use `sifli_board_*`.
+- Project creation or clangd setup: use `sifli_project_*`.
+- Build, rebuild, clean, download, or menuconfig: use `sifli_build_*`.
+- Serial port selection or monitor interaction: use `sifli_serial_*` or `sifli_monitor_*`.
+- Workflow validation, listing, inspection, or execution: use `sifli_workflow_*`.
+
+These underscore names are Codex-style wrappers. Other agents may expose raw MCP names such as `sifli.project.getState` or VS Code LM tool names such as `sifli-sdk-codekit_getProjectState`. If names differ, map by purpose rather than spelling. See `references/tools.md`.
+
+Use shell commands only for repository development tasks, direct file edits, explicit user-requested shell examples, or after the user approves a non-CodeKit fallback. Do not silently replace build, download, board, or serial operations with shell commands when CodeKit MCP is missing; first diagnose or connect CodeKit.
+
+## Multi-Agent Compatibility
+
+CodeKit can appear differently depending on the host agent:
+
+| Environment | Typical Tool Surface | Example State Tool |
+|-------------|----------------------|--------------------|
+| Codex MCP wrapper | Function-style names | `sifli_project_getState` |
+| Raw MCP clients | Server tool names | `sifli.project.getState` |
+| VS Code LM tools | Extension-contributed LM names | `sifli-sdk-codekit_getProjectState` |
+| Generic agents | Adapter-specific aliases | Check the current tool list |
+
+Before calling a tool:
+
+1. Inspect the current available tool list or MCP server capabilities.
+2. Prefer the current environment's exact CodeKit tool name.
+3. If several equivalent tools exist, prefer MCP tools for external agents and VS Code LM tools only inside VS Code chat/LM contexts.
+4. If no CodeKit tools are visible, follow `references/installation.md` for the current client. Do not guess tool names.
+
+## Core Pattern
+
+Instead of composing shell commands that bypass CodeKit state:
+
+```text
+# ❌ Shell: bypasses CodeKit SDK/board/port state, fragile paths
+cd ~/sifli-project
+./build.sh --board sf32lb52-lcd_n16r8
+sftool write_flash --port /dev/ttyUSB0 --addr 0x12000000 app.bin
+```
+
+Drive the same flow through CodeKit MCP tools, using the current agent's exposed names:
+
+```text
+# ✅ CodeKit: stateful, no path guessing, integrated
+project state                   # e.g. sifli_project_getState or sifli.project.getState
+SDK activate                    # or list SDKs, then activate
+board select                    # or list boards, then select
+build compile                   # narrowest tool
+build download                  # uses selected board + serial port
+```
+
+CodeKit preserves selected SDK, board, serial port, and project across operations. Shell commands require re-deriving this context each time.
+
+## Decision Flowchart
+
+```
+Is CodeKit MCP available?
+├── No  → Follow references/installation.md to set up connection.
+│         If still unavailable → ask before using non-CodeKit fallback.
+├── Yes → Does the task match an MCP tool?
+│         ├── SDK/board/project setup    → sifli_sdk_*, sifli_board_*, sifli_project_*
+│         ├── Build/download/menuconfig  → sifli_build_*
+│         ├── Serial/monitor             → sifli_serial_*, sifli_monitor_*
+│         ├── Workflow                   → sifli_workflow_*
+│         └── No match → Is it raw flash/sftool territory?
+│                       ├── Yes → Use sftool skill
+│                       └── No  → Use shell commands
+```
+
+## Safe Workflow
+
+1. Check CodeKit state with the current environment's project-state tool.
+2. If no CodeKit tools are available, follow `references/installation.md` for the current agent/client.
+3. For existing projects, select or activate prerequisites before build actions:
+   - Activate SDK before board-dependent work.
+   - Select a board before build/download/menuconfig.
+   - Select a serial port before download or serial operations.
+4. Use the narrowest tool that matches the request. Do not run a full rebuild when compile is enough.
+5. Treat tools that open UI or require host interaction (e.g. menuconfig or monitor-open tools) as stateful operations. After launching, tell the user what opened and what they need to do, then ask whether to wait or continue. Do not assume the action completed just because the tool returned.
+6. After build/download/serial operations, read the returned status or logs before claiming success.
+
+## When NOT to Use
+
+- **Raw flash readback, explicit address/size operations, chip-memory compatibility** → Use the separate `sftool` skill instead.
+- **Developing or debugging the CodeKit extension itself** → This is repository development work, use shell commands.
+- **CI/CD pipeline setup, bulk file operations, or git workflows** → Shell commands are more appropriate.
+- **When the CodeKit MCP server is unreachable** → Follow `references/installation.md` to set up the connection; use shell fallback only with user approval or for repository development work.
+- **If the user explicitly asks for shell/build/sftool commands** → Honor the request; do not override with MCP tools.
+
+## Red Flags
+
+Stop and re-evaluate when you catch yourself thinking or doing any of these:
+
+| Thought / Action | Why It's Wrong |
+|-----------------|----------------|
+| "I'll just guess the serial port — it's probably /dev/ttyUSB0" | Wrong port causes download failures or bricking. Always list ports. |
+| "The board name is probably..." | Board names vary by SDK version and config. Always call `sifli_board_list`. |
+| "Let me run a full rebuild to be safe" | Wastes time; use `sifli_build_compile` first, rebuild only if stale. |
+| "I'll just run the MCP tool without checking state first" | Without the project-state tool you don't know what's active. |
+| "This token is just for config, I can show it" | Bearer tokens grant control; expose only when user explicitly needs connection details. |
+| "The shell command is faster than finding the right MCP tool" | Bypassing CodeKit loses state and creates fragile ad-hoc workflows. |
+| "The tool name must be `sifli_project_getState` everywhere" | Tool names differ by agent. Match by purpose and current tool list. |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Activating SDK or selecting board without checking current state first | Always call the project-state tool before making changes. |
+| Running `sifli_build_rebuild` when `sifli_build_compile` would suffice | Use compile for incremental builds; rebuild only when outputs are suspected stale. |
+| Guessing serial port paths or board names | Always use `sifli_serial_listPorts` and `sifli_board_list` to discover available options. |
+| Attempting download without confirming board and serial port selection | Check `selectedBoard` and `selectedSerialPort` in project state before download. |
+| Exposing or committing bearer tokens in config files | Keep tokens local; add `.mcp.json` to `.gitignore` if needed. |
+| Printing `.mcp.json` to prove the server exists | Report only server name, host/port, and whether a token is present; do not echo the token. |
+| Calling workflows without prior validation | Always call the workflow-validation tool before saving or running a workflow. |
+| Ignoring `sifli_build_menuconfig` return status or logs | Menuconfig opens in a VS Code terminal and returns once launched; read the output before claiming success. |
+
+## Task Map
+
+- For MCP installation, connection info, `.mcp.json`, and Codex CLI setup, read `references/installation.md`.
+- For tool names, required inputs, and common operation order, read `references/tools.md`.
+- For reusable CodeKit workflows and workflow JSON shape, read `references/workflows.md`.
+- For serial/MCP/build failure handling, read `references/troubleshooting.md`.
+- For OpenAI/Codex agent interface description, see `agents/openai.yaml`.
+
+## Boundaries
+
+- Use the separate `sftool` skill for low-level raw flash readback, JSON flash configs, explicit flash addresses, chip-memory compatibility, or direct `sftool` CLI usage.
+- Prefer CodeKit for normal extension-managed build/download/monitor flows because it preserves selected SDK, board, project, and serial state.
+- Do not guess SDK paths, board names, serial ports, workflow refs, baud rates, or destructive erase operations.
+- Do not expose bearer tokens in final answers unless the user explicitly asks for connection configuration details.
+- Do not assume one agent's CodeKit tool spelling applies to another agent. Check the current tool surface first.
+
+*Last updated: 2026-06-09*

--- a/skills/sifli-sdk-codekit/agents/openai.yaml
+++ b/skills/sifli-sdk-codekit/agents/openai.yaml
@@ -1,0 +1,12 @@
+interface:
+  display_name: "CodeKit"
+  short_description: "Use SiFli CodeKit MCP tools for SiFli SDK project management, builds, serial, and workflows"
+  default_prompt: "Check the project state with the CodeKit tool exposed by the current agent. In Codex this is typically sifli_project_getState; raw MCP clients may expose sifli.project.getState; VS Code LM contexts may expose sifli-sdk-codekit_getProjectState. Then use the appropriate CodeKit tool for SDK, board, build/download/menuconfig, serial/monitor, or workflow tasks. Do not guess board names, serial ports, baud rates, or bearer tokens."
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "codekit"
+      description: "SiFli SDK CodeKit embedded MCP server"
+      transport: "streamable_http"
+      notes: "Tool names may be normalized by the host agent. Map by purpose and schema rather than exact spelling."

--- a/skills/sifli-sdk-codekit/references/installation.md
+++ b/skills/sifli-sdk-codekit/references/installation.md
@@ -1,0 +1,107 @@
+# Installation And MCP Connection
+
+Use this reference when CodeKit MCP tools are missing or the user asks to install/connect the MCP server.
+
+## Prerequisites
+
+- VS Code must have the SiFli SDK CodeKit extension installed and enabled.
+- The VS Code window that hosts CodeKit must stay open while external MCP clients use the server.
+- The embedded MCP server is HTTP streamable and serves `/mcp`.
+
+## Start CodeKit MCP In VS Code
+
+Use the command palette in the CodeKit-hosting VS Code window:
+
+1. Run `Start SiFli MCP Server`.
+2. Run `Show SiFli MCP Connection Info`.
+3. Copy the URL and Bearer token.
+
+Optional settings:
+
+- `sifli-sdk-codekit.mcp.enabled`: enable or disable the embedded server.
+- `sifli-sdk-codekit.mcp.autoStart`: start automatically when the extension activates.
+- `sifli-sdk-codekit.mcp.host`: default `127.0.0.1`.
+- `sifli-sdk-codekit.mcp.port`: use `0` for a random available port, or a fixed port such as `12345`.
+- `sifli-sdk-codekit.mcp.fixedToken`: set only when a stable token is required.
+
+## Add To MCP Clients
+
+Different agents load MCP servers differently. Use the current client's native configuration path when known; use `.mcp.json` only for clients that explicitly read it.
+
+Before editing any MCP configuration, actively ask the user for the CodeKit MCP URL and Bearer token shown by `Show SiFli MCP Connection Info`. Do not invent, reuse, or copy a token from another workspace unless the user explicitly confirms it.
+
+Ask for:
+
+- MCP URL, for example `http://127.0.0.1:12345/mcp`
+- Bearer token
+- Which agent/client should be configured
+- Whether they want the config written to a workspace-local file, a user-level config, or the client's MCP registry
+
+### Workspace `.mcp.json`
+
+For clients that read workspace `.mcp.json`, add or update this streamable HTTP server entry after the user provides values and approves writing the file:
+
+```json
+{
+  "mcpServers": {
+    "codekit": {
+      "type": "http",
+      "url": "http://127.0.0.1:12345/mcp",
+      "headers": {
+        "Authorization": "Bearer <TOKEN_FROM_CODEKIT>"
+      }
+    }
+  }
+}
+```
+
+Keep tokens local. Do not commit real tokens.
+
+### Codex CLI (Apple)
+
+If using Apple's **Codex CLI** command-line agent, prefer the MCP registry with an environment variable for the token:
+
+```bash
+export CODEKIT_MCP_TOKEN="<TOKEN_FROM_CODEKIT>"
+/Applications/Codex.app/Contents/Resources/codex mcp add codekit \
+  --url http://127.0.0.1:12345/mcp \
+  --bearer-token-env-var CODEKIT_MCP_TOKEN
+```
+
+Use the actual URL from `Show SiFli MCP Connection Info`.
+
+### Other Agents
+
+- **Claude Code:** use Claude Code's current MCP configuration mechanism for streamable HTTP servers. If it supports workspace `.mcp.json`, the JSON above is appropriate; otherwise use its native MCP add/config command.
+- **VS Code MCP clients:** prefer the CodeKit extension's MCP server definition provider when available, or configure a streamable HTTP MCP server pointing to `/mcp`.
+- **Copilot CLI / Gemini CLI / generic MCP clients:** configure a streamable HTTP MCP server with `Authorization: Bearer <token>` using the client's documented config shape.
+
+When unsure, do not guess the config file format. Ask the user which client they want to configure or inspect that client's documented config in the workspace.
+
+## Verify The Connection
+
+After adding the server, restart or reload the client session so tools appear. A successful setup exposes tools with names like:
+
+- `sifli_project_getState`
+- `sifli_sdk_list`
+- `sifli_board_list`
+- `sifli_build_compile`
+- `sifli_serial_listPorts`
+- `sifli_workflow_list`
+
+Raw MCP clients may instead show dotted names such as `sifli.project.getState`; VS Code chat/LM contexts may show extension names such as `sifli-sdk-codekit_getProjectState`. See `tools.md` for the mapping.
+
+If tools do not appear, read `troubleshooting.md`.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Guessing or reusing a bearer token from another workspace | Actively ask the user for the current token from VS Code. |
+| Committing `.mcp.json` with a real token | Add `.mcp.json` to `.gitignore`, or use environment variables. |
+| Printing `.mcp.json` while debugging | Report only whether the server entry and token are present; never echo the bearer token. |
+| Setting a fixed port without telling the user | Use `mcp.port: 0` for random port, or document the chosen port. |
+| Expecting MCP tools to appear without restarting the client | Restart or reload the client session after writing `.mcp.json`. |
+| Trying to connect while VS Code is closed | The MCP server runs inside VS Code; VS Code must stay open. |
+
+*Last updated: 2026-06-09*

--- a/skills/sifli-sdk-codekit/references/installation.md
+++ b/skills/sifli-sdk-codekit/references/installation.md
@@ -10,13 +10,11 @@ Use this reference when CodeKit MCP tools are missing or the user asks to instal
 
 ## Start CodeKit MCP In VS Code
 
-Use the command palette in the CodeKit-hosting VS Code window:
+Open the CodeKit extension's configuration view in VS Code. Enable the MCP server from the extension UI — the panel displays the connection URL and Bearer token. Copy the token.
 
-1. Run `Start SiFli MCP Server`.
-2. Run `Show SiFli MCP Connection Info`.
-3. Copy the URL and Bearer token.
+Then, in the CodeKit extension's **"配置端点" (Configure Endpoint)** field, paste the copied token. This sets a fixed token so it does not change when VS Code or the extension restarts — without this step, a new random token is generated on each start, and every MCP client configuration would need to be updated.
 
-Optional settings:
+If the extension view is not accessible, there are also VS Code settings available:
 
 - `sifli-sdk-codekit.mcp.enabled`: enable or disable the embedded server.
 - `sifli-sdk-codekit.mcp.autoStart`: start automatically when the extension activates.
@@ -28,7 +26,7 @@ Optional settings:
 
 Different agents load MCP servers differently. Use the current client's native configuration path when known; use `.mcp.json` only for clients that explicitly read it.
 
-Before editing any MCP configuration, actively ask the user for the CodeKit MCP URL and Bearer token shown by `Show SiFli MCP Connection Info`. Do not invent, reuse, or copy a token from another workspace unless the user explicitly confirms it.
+Before editing any MCP configuration, ask the user to open the CodeKit extension's configuration view where the connection URL and Bearer token are displayed. Do not invent, reuse, or copy a token from another workspace unless the user explicitly confirms it.
 
 Ask for:
 
@@ -70,7 +68,7 @@ export CODEKIT_MCP_TOKEN="<TOKEN_FROM_CODEKIT>"
   --bearer-token-env-var CODEKIT_MCP_TOKEN
 ```
 
-Use the actual URL from `Show SiFli MCP Connection Info`.
+Use the actual URL from the CodeKit extension's connection info display.
 
 ### Other Agents
 

--- a/skills/sifli-sdk-codekit/references/installation.md
+++ b/skills/sifli-sdk-codekit/references/installation.md
@@ -37,9 +37,9 @@ Ask for:
 - Which agent/client should be configured
 - Whether they want the config written to a workspace-local file, a user-level config, or the client's MCP registry
 
-### Workspace `.mcp.json`
+### Claude Code — Project `.mcp.json`
 
-For clients that read workspace `.mcp.json`, add or update this streamable HTTP server entry after the user provides values and approves writing the file:
+If the host agent is **Claude Code**, configure CodeKit MCP by creating a `.mcp.json` file in the project root directory (next to this workspace's root). Add or update this streamable HTTP server entry after the user provides values and approves writing the file:
 
 ```json
 {
@@ -54,6 +54,8 @@ For clients that read workspace `.mcp.json`, add or update this streamable HTTP 
   }
 }
 ```
+
+Claude Code reads `.mcp.json` from the project root on startup. After creating or updating the file, restart the Claude Code session so the tools appear.
 
 Keep tokens local. Do not commit real tokens.
 
@@ -72,11 +74,13 @@ Use the actual URL from `Show SiFli MCP Connection Info`.
 
 ### Other Agents
 
-- **Claude Code:** use Claude Code's current MCP configuration mechanism for streamable HTTP servers. If it supports workspace `.mcp.json`, the JSON above is appropriate; otherwise use its native MCP add/config command.
-- **VS Code MCP clients:** prefer the CodeKit extension's MCP server definition provider when available, or configure a streamable HTTP MCP server pointing to `/mcp`.
-- **Copilot CLI / Gemini CLI / generic MCP clients:** configure a streamable HTTP MCP server with `Authorization: Bearer <token>` using the client's documented config shape.
+For agents other than Claude Code, installation steps depend on the host environment. Follow that agent's own MCP configuration documentation:
 
-When unsure, do not guess the config file format. Ask the user which client they want to configure or inspect that client's documented config in the workspace.
+- **Codex CLI (Apple):** use the `codex mcp add` command with `--bearer-token-env-var` (see Codex CLI docs).
+- **Copilot CLI / Gemini CLI / generic MCP clients:** configure a streamable HTTP MCP server with `Authorization: Bearer <token>` using the client's documented config shape.
+- **VS Code MCP clients:** prefer the CodeKit extension's MCP server definition provider when available; otherwise configure a streamable HTTP MCP server pointing to `/mcp`.
+
+When unsure, do not guess the config file format. Ask the user which client they want to configure, or inspect that client's documented config in the workspace.
 
 ## Verify The Connection
 

--- a/skills/sifli-sdk-codekit/references/tools.md
+++ b/skills/sifli-sdk-codekit/references/tools.md
@@ -1,0 +1,122 @@
+# CodeKit MCP Tool Guide
+
+Use this reference to choose tools and operation order.
+
+## Quick Reference
+
+Use the spelling exposed by the current agent. The table below uses Codex wrapper names because they are readable in this repository's Codex environment.
+
+| Category | Tool | Purpose | Run First |
+|----------|------|---------|-----------|
+| **State** | `sifli_project_getState` | Inspect project, SDK, board, serial, monitor, workflows | ✅ Always first |
+| **SDK** | `sifli_sdk_list` | List configured SDKs | Before activate |
+| | `sifli_sdk_activate` | Activate SDK by path or version | |
+| **Board** | `sifli_board_list` | List available boards | Before select |
+| | `sifli_board_select` | Select active board (+ optional thread count) | |
+| | `sifli_project_configureClangd` | Update clangd args + `.clangd` for selected board | After board select |
+| **Project** | `sifli_project_listTemplates` | List creatable SDK example templates | |
+| | `sifli_project_createFromExample` | Create project from SDK example | |
+| **Build** | `sifli_build_compile` | Incremental compile | Prefer over rebuild |
+| | `sifli_build_rebuild` | Clean + compile | Only when outputs stale |
+| | `sifli_build_clean` | Delete build output | Only when requested |
+| | `sifli_build_download` | Flash to selected serial device | After board + port selected |
+| | `sifli_build_menuconfig` | Open menuconfig in VS Code terminal | |
+| **Serial** | `sifli_serial_listPorts` | List serial ports | Before select |
+| | `sifli_serial_selectPort` | Select download/log serial port | |
+| | `sifli_serial_connect` | Connect MCP-driven serial session | |
+| | `sifli_serial_write` | Write text or hex bytes | |
+| | `sifli_serial_read` | Read buffered serial logs | |
+| | `sifli_serial_status` | Inspect active serial session | |
+| | `sifli_serial_reset` | Pulse DTR/RTS to reset device | |
+| | `sifli_serial_disconnect` | Disconnect active serial session | |
+| **Monitor** | `sifli_monitor_open` | Open VS Code serial monitor | For user-visible logs |
+| | `sifli_monitor_close` | Close active monitor | |
+| **Workflow** | `sifli_workflow_list` | List workflows | |
+| | `sifli_workflow_get` | Inspect one workflow + compatibility | Before run |
+| | `sifli_workflow_validate` | Validate workflow JSON | Before save/run |
+| | `sifli_workflow_run` | Run workflow by ref (+ optional inputs) | |
+
+## Tool Name Mapping
+
+Different agents expose the same CodeKit capability with different names. Match by purpose and schema.
+
+| Purpose | Raw MCP Tool | Codex Wrapper | VS Code LM Tool |
+|---------|--------------|---------------|-----------------|
+| Project state | `sifli.project.getState` | `sifli_project_getState` | `sifli-sdk-codekit_getProjectState` |
+| List SDKs | `sifli.sdk.list` | `sifli_sdk_list` | Not exposed |
+| Activate SDK | `sifli.sdk.activate` | `sifli_sdk_activate` | Not exposed |
+| List boards | `sifli.board.list` | `sifli_board_list` | `sifli-sdk-codekit_listBoards` |
+| Select board | `sifli.board.select` | `sifli_board_select` | `sifli-sdk-codekit_selectBoard` |
+| Configure clangd | `sifli.project.configureClangd` | `sifli_project_configureClangd` | Not exposed |
+| List templates | `sifli.project.listTemplates` | `sifli_project_listTemplates` | Not exposed |
+| Create from example | `sifli.project.createFromExample` | `sifli_project_createFromExample` | Not exposed |
+| Compile | `sifli.build.compile` | `sifli_build_compile` | `sifli-sdk-codekit_compile` |
+| Rebuild | `sifli.build.rebuild` | `sifli_build_rebuild` | `sifli-sdk-codekit_rebuild` |
+| Clean | `sifli.build.clean` | `sifli_build_clean` | `sifli-sdk-codekit_clean` |
+| Download | `sifli.build.download` | `sifli_build_download` | `sifli-sdk-codekit_download` |
+| Menuconfig | `sifli.build.menuconfig` | `sifli_build_menuconfig` | Not exposed |
+| List serial ports | `sifli.serial.listPorts` | `sifli_serial_listPorts` | `sifli-sdk-codekit_listSerialPorts` |
+| Select serial port | `sifli.serial.selectPort` | `sifli_serial_selectPort` | `sifli-sdk-codekit_selectSerialPort` |
+| Serial connect | `sifli.serial.connect` | `sifli_serial_connect` | Not exposed |
+| Serial read | `sifli.serial.read` | `sifli_serial_read` | Not exposed |
+| Serial write | `sifli.serial.write` | `sifli_serial_write` | Not exposed |
+| Serial reset | `sifli.serial.reset` | `sifli_serial_reset` | Not exposed |
+| Serial status | `sifli.serial.status` | `sifli_serial_status` | Not exposed |
+| Serial disconnect | `sifli.serial.disconnect` | `sifli_serial_disconnect` | Not exposed |
+| Open monitor | `sifli.monitor.open` | `sifli_monitor_open` | `sifli-sdk-codekit_openMonitor` |
+| Close monitor | `sifli.monitor.close` | `sifli_monitor_close` | `sifli-sdk-codekit_closeMonitor` |
+| List workflows | `sifli.workflow.list` | `sifli_workflow_list` | `sifli-sdk-codekit_listWorkflows` |
+| Get workflow | `sifli.workflow.get` | `sifli_workflow_get` | Not exposed |
+| Validate workflow | `sifli.workflow.validate` | `sifli_workflow_validate` | Not exposed |
+| Run workflow | `sifli.workflow.run` | `sifli_workflow_run` | `sifli-sdk-codekit_runWorkflow` |
+
+Notes:
+
+- VS Code LM tools are available only in VS Code language model contexts and may be gated by `when` clauses such as `sifli.isProject`.
+- Raw MCP clients may show dotted names exactly as registered by the CodeKit MCP server.
+- Codex and some other agents normalize MCP names into function-safe wrapper names.
+- If a tool is missing in one surface, use the nearest CodeKit MCP equivalent rather than shelling out.
+
+## Operation Order
+
+### SDK → Board → Clangd
+
+```
+sifli_sdk_list → sifli_sdk_activate
+              → sifli_board_list → sifli_board_select
+                                 → sifli_project_configureClangd
+```
+
+Do not guess board names. Use `sifli_board_list` or ask the user.
+
+### Build → Download
+
+```
+sifli_project_getState (confirm selectedBoard + selectedSerialPort exist)
+→ sifli_build_compile (prefer over rebuild)
+→ sifli_build_download
+```
+
+Use `compile` for incremental builds, `rebuild` for suspected stale outputs, and `clean` only when requested or needed.
+
+### Serial: Agent-Driven vs User-Visible
+
+| Goal | Tool |
+|------|------|
+| Agent reads device logs | `sifli_serial_connect` → read/write/disconnect |
+| User watches serial output | `sifli_monitor_open` / `sifli_monitor_close` |
+
+Some MCP clients do not support experimental task tools. If `menuconfig` or `monitor.open` reports `input_required`, starts a host-side UI, or cannot be polled by the client, tell the user what opened in VS Code and ask whether to continue, wait, or use the VS Code command palette fallback.
+
+## Project Creation
+
+Required decisions for `sifli_project_createFromExample`:
+
+- `exampleId`
+- `targetPath`
+- optional `sdkPath` or `sdkVersion`
+- optional `initializeGit`
+
+Do not overwrite an existing target path unless the user explicitly approves.
+
+*Last updated: 2026-06-09*

--- a/skills/sifli-sdk-codekit/references/troubleshooting.md
+++ b/skills/sifli-sdk-codekit/references/troubleshooting.md
@@ -1,0 +1,73 @@
+# Troubleshooting
+
+## MCP Tools Are Missing
+
+First detect whether the current agent already has CodeKit MCP access:
+
+1. Check whether tools named like `sifli_project_getState`, `sifli_sdk_list`, or `sifli_build_compile` are available in the current tool list.
+2. If raw MCP tools are visible instead, look for dotted names like `sifli.project.getState`, `sifli.sdk.list`, or `sifli.build.compile`.
+3. If VS Code LM tools are visible instead, look for extension names like `sifli-sdk-codekit_getProjectState`, `sifli-sdk-codekit_listBoards`, or `sifli-sdk-codekit_compile`.
+4. If any equivalent tools are available, call the current environment's project-state tool to verify the server responds.
+5. If the tools are not available, inspect the current workspace MCP configuration when allowed, such as `.mcp.json`, to see whether a `codekit` MCP server is already configured. Do not print bearer tokens.
+6. If no CodeKit MCP server is installed or configured for the current agent, ask the user whether they want to install/connect it before making hardware-affecting changes.
+
+When the user agrees to install or connect CodeKit MCP:
+
+1. Confirm VS Code is open with the SiFli SDK CodeKit extension installed.
+2. Ask the user to start the server with `Start SiFli MCP Server`.
+3. Ask the user to show connection info with `Show SiFli MCP Connection Info`.
+4. Ask the user for the exact MCP URL and Bearer token.
+5. Ask which agent/client should be configured and whether to write the configuration to a workspace-local file, user-level config, or client MCP registry.
+6. Restart or reload the agent session after configuration changes so MCP tools are re-discovered.
+
+The embedded server runs inside the VS Code extension host. If VS Code closes, external MCP clients lose access.
+
+## Unauthorized Or 401
+
+- Refresh connection info in VS Code.
+- Confirm the header is `Authorization: Bearer <token>`.
+- If using Codex CLI, confirm the environment variable named by `--bearer-token-env-var` exists in the launching environment.
+- If `fixedToken` changed, restart the MCP server and update clients.
+
+## Port Or URL Mismatch
+
+- CodeKit serves `/mcp`, not `/`.
+- If `mcp.port` is `0`, CodeKit chooses a random available port each start. Use `Show SiFli MCP Connection Info`.
+- Use a fixed port only when the user needs stable configuration.
+
+## Build Fails
+
+Check state in this order:
+
+1. Current environment's project-state tool
+2. Active SDK exists.
+3. Selected board exists.
+4. Current workspace is a SiFli project.
+5. Try `sifli_build_compile` before `sifli_build_rebuild`.
+
+If the failure is toolchain/path related, use CodeKit SDK activation and clangd configuration before shell-level fixes.
+
+## Download Or Serial Fails
+
+- Run `sifli_serial_listPorts`.
+- Select the exact port with `sifli_serial_selectPort`.
+- Close conflicting serial monitors or tools.
+- Confirm baud rates in project state.
+- Use `sifli_monitor_close` or `sifli_serial_disconnect` before reconnecting if the port is busy.
+
+## When To Switch To `sftool`
+
+Use the `sftool` skill for raw flash operations, explicit address/size readbacks, `sftool` JSON configs, compatibility flags, chip-memory matrix decisions, or any request that names the `sftool` CLI directly.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Rebuilding when compile would suffice | Try `sifli_build_compile` first; escalate to `rebuild` only if stale. |
+| Skipping state check before troubleshooting | Always start with the project-state tool — it reveals SDK/board/serial state. |
+| Assuming MCP tools are available without checking | Check the client tool list or `.mcp.json` before trying MCP commands. |
+| Treating Codex wrapper names as universal | Map by purpose: Codex uses underscores, raw MCP uses dotted names, VS Code LM tools use `sifli-sdk-codekit_*`. |
+| Attempting serial download without closing monitor | Call `sifli_monitor_close` or `sifli_serial_disconnect` before reconnecting. |
+| Guessing port/URL when connection info is stale | Re-run `Show SiFli MCP Connection Info` in VS Code for current values. |
+
+*Last updated: 2026-06-09*

--- a/skills/sifli-sdk-codekit/references/workflows.md
+++ b/skills/sifli-sdk-codekit/references/workflows.md
@@ -1,0 +1,107 @@
+# CodeKit Workflows
+
+Use workflows for repeatable CodeKit actions such as clean-build-download-monitor or board-specific setup.
+
+## Workflow Shape
+
+Workflow payloads contain:
+
+- `id`: stable identifier.
+- `name`: user-facing name.
+- `description`: optional summary.
+- `inputs`: optional prompted values.
+- `steps`: ordered step list.
+- `failurePolicy`: `stop` or `continue`.
+
+### Supported Step Types
+
+| Step Type | Purpose |
+|-----------|---------|
+| `build.compile` | Incremental compile |
+| `build.rebuild` | Clean + compile |
+| `build.clean` | Delete build output |
+| `build.download` | Flash to selected serial device |
+| `build.menuconfig` | Open menuconfig in VS Code terminal |
+| `shell.command` | Run a shell command |
+| `monitor.open` | Open VS Code serial monitor |
+| `monitor.close` | Close active monitor |
+| `serial.selectPort` | Select serial port |
+
+### Step Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | ✅ | Step type from table above |
+| `name` | ❌ | Optional label |
+| `args` | ❌ | Step-specific arguments (e.g. `monitorBaud`, `command`) |
+| `wait` | ❌ | Whether to wait for completion |
+| `continueOnError` | ❌ | Override `failurePolicy` for this step |
+| `runIf` | ❌ | Conditions: `boardSelected`, `serialPortSelected`, `monitorActive` |
+
+## Validation First
+
+Always call the current environment's equivalent of `sifli_workflow_validate` before saving or recommending a workflow payload. Prefer validating the exact object the user will use.
+
+Tool name examples:
+
+- Codex wrapper: `sifli_workflow_validate`
+- Raw MCP: `sifli.workflow.validate`
+- VS Code LM tools: not exposed; use CodeKit UI or MCP validation instead
+
+## Example: Build → Download → Monitor
+
+```json
+{
+  "id": "build-download-monitor",
+  "name": "Build, Download, Monitor",
+  "description": "Compile the active project, download it, then open the serial monitor.",
+  "failurePolicy": "stop",
+  "steps": [
+    {
+      "name": "Compile",
+      "type": "build.compile",
+      "wait": true,
+      "runIf": {
+        "boardSelected": true
+      }
+    },
+    {
+      "name": "Download",
+      "type": "build.download",
+      "wait": true,
+      "runIf": {
+        "boardSelected": true,
+        "serialPortSelected": true
+      }
+    },
+    {
+      "name": "Open monitor",
+      "type": "monitor.open",
+      "args": {
+        "monitorBaud": 1000000
+      },
+      "wait": false
+    }
+  ]
+}
+```
+
+> **Baud rate note:** The `monitorBaud` value (e.g., `1000000`) depends on the target device and firmware configuration. Check the device datasheet or `sifli_serial_status` output before choosing a rate. Common SiFli baud rates: `921600`, `1000000`, `2000000`. Do not guess — ask the user or inspect the current project configuration.
+
+## Running a Workflow
+
+Use the current environment's equivalent of `sifli_workflow_get` to inspect compatibility, then run with the workflow ref. If the workflow defines `inputs`, provide an `inputs` map keyed by input `key`.
+
+If only VS Code LM tools are available, `runWorkflow` may be available but `get` and `validate` may not be. In that case, prefer the CodeKit workflow UI or connect the MCP server before recommending or running a new workflow payload.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Saving or running a workflow without validation | Always call the current environment's workflow-validation tool first. |
+| Using a non-existent step type | Check the supported step types table above. |
+| Forgetting `runIf` conditions for download steps | Add `boardSelected` and `serialPortSelected` gates. |
+| Hard-coding port names or baud rates | Use `serial.selectPort` step or user inputs instead. |
+| Setting `failurePolicy: continue` without `continueOnError` on specific steps | Either keep `failurePolicy: stop` or add `continueOnError` per step. |
+
+*Last updated: 2026-06-09 • CodeKit workflow format v1*


### PR DESCRIPTION
## Summary

- Add the `sifli-sdk-codekit` skill for Claude Code, Codex, and GitHub Copilot.
- Document CodeKit MCP connection setup, fixed-token configuration, tool usage, workflows, and troubleshooting.
- Add user-facing MCP and Skills docs, then link them from README and feature documentation.
- Ignore local agent and MCP metadata files generated during setup.

## Changes

- Added Skill entry files under `skills/sifli-sdk-codekit/`, including agent metadata and reference docs.
- Clarified MCP setup guidance for Claude Code and fixed-token workflows.
- Added `docs/src/Feature/mcp-and-skills.md` with MCP tool categories and Skills installation instructions.
- Updated `README.md`, `README_EN.md`, and `docs/src/Feature/README.md` to surface the new MCP and Skills docs.
- Updated `.gitignore` for `.codegraph/`, `.mcp.json`, and `.claude/`.

## Validation

- Ran `git diff --check`.
- Confirmed branch `adapt-codekit-skill-agents` is pushed to `origin`.

## Commits

- `015b1c0 feat(skills): adapt CodeKit skill for multiple agents`
- `4472587 fix(skills): clarify CodeKit MCP setup for Claude Code`
- `2216249 fix(skills): clarify CodeKit fixed token setup`
- `acbc668 feat(docs): add MCP and Skills documentation`