### PR TITLE
fix(serial): enhance CSS handling in Vue webview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ designs/
 .codegraph/
 .mcp.json
 .claude/
+.planning/

--- a/src/services/builtinSerialMonitorService.ts
+++ b/src/services/builtinSerialMonitorService.ts
@@ -770,7 +770,6 @@ export class BuiltinSerialMonitorService {
     if (typeof settings.renderAnsi === 'boolean') {
       await this.workspaceStateService.setSerialMonitorRenderAnsi(settings.renderAnsi);
     }
-
     const nextBaudRate = this.resolveLogBaudRate(settings.logBaudRate);
     if (nextBaudRate === undefined) {
       return false;

--- a/src/test/vueWebviewAssets.test.ts
+++ b/src/test/vueWebviewAssets.test.ts
@@ -25,10 +25,16 @@ describe('vueWebviewAssets', () => {
     return dir;
   }
 
-  it('loads only the default entry css for the main Vue webview', () => {
+  it('loads the default entry css and shared xterm css for the main Vue webview', () => {
     const distPath = createDistWithCssFiles(['index.css', 'buildLogs.css', 'xterm.css']);
 
-    assert.deepStrictEqual(resolveVueWebviewCssFiles(distPath), ['assets/index.css']);
+    assert.deepStrictEqual(resolveVueWebviewCssFiles(distPath), ['assets/index.css', 'assets/xterm.css']);
+  });
+
+  it('keeps unrelated entry css out of the main Vue webview', () => {
+    const distPath = createDistWithCssFiles(['index.css', 'buildLogs.css', 'memoryMap.css', 'xterm.css']);
+
+    assert.deepStrictEqual(resolveVueWebviewCssFiles(distPath), ['assets/index.css', 'assets/xterm.css']);
   });
 
   it('uses explicit css files for the build logs webview', () => {

--- a/src/utils/vueWebviewAssets.ts
+++ b/src/utils/vueWebviewAssets.ts
@@ -15,6 +15,9 @@ export function resolveVueWebviewCssFiles(
   const scriptName = path.posix.basename(normalizedScriptFile, path.posix.extname(normalizedScriptFile));
   const entryCssFile = path.posix.join(scriptDir, `${scriptName}.css`);
   const entryCssPath = path.join(vueDistPath, ...entryCssFile.split('/'));
+  const sharedCssFiles = ['xterm.css']
+    .map(file => path.posix.join(scriptDir, file))
+    .filter(file => file !== entryCssFile && fs.existsSync(path.join(vueDistPath, ...file.split('/'))));
 
-  return fs.existsSync(entryCssPath) ? [entryCssFile] : [];
+  return fs.existsSync(entryCssPath) ? [entryCssFile, ...sharedCssFiles] : sharedCssFiles;
 }

--- a/webview-vue/src/components/layout/AppShell.vue
+++ b/webview-vue/src/components/layout/AppShell.vue
@@ -57,7 +57,7 @@ const isStandaloneRoute = computed(
 const showBackButton = computed(() => route.path !== '/' && !isStandaloneRoute.value);
 const rootClass = computed(() =>
   isViewportLockedRoute.value
-    ? 'h-screen min-h-0 overflow-hidden p-0 text-vscode-foreground'
+    ? 'h-full min-h-0 overflow-hidden p-0 text-vscode-foreground'
     : 'min-h-screen p-0 text-vscode-foreground'
 );
 const shellClass = computed(() =>

--- a/webview-vue/src/views/SerialMonitorPage.vue
+++ b/webview-vue/src/views/SerialMonitorPage.vue
@@ -394,7 +394,9 @@ const disposables: Array<() => void> = [];
 
 onMounted(() => {
   window.addEventListener('keydown', handleGlobalKeydown);
+  window.addEventListener('resize', handleWindowResize);
   disposables.push(() => window.removeEventListener('keydown', handleGlobalKeydown));
+  disposables.push(() => window.removeEventListener('resize', handleWindowResize));
   disposables.push(
     onMessage<{ snapshot: SerialMonitorSnapshot }>('serialMonitorSnapshot', payload => {
       applySnapshot(payload.snapshot);
@@ -684,6 +686,7 @@ async function initializeTerminal() {
       allowProposedApi: true,
       convertEol: true,
       cursorBlink: true,
+      cursorStyle: 'bar',
       fontFamily: "Menlo, Monaco, 'Courier New', monospace",
       fontSize: 13,
       scrollback: 5000,
@@ -832,6 +835,13 @@ function fitTerminal() {
   } catch {
     // xterm can throw while the container is not measurable during webview layout churn.
   }
+}
+
+function handleWindowResize() {
+  if (!terminalMode.value || !terminal) {
+    return;
+  }
+  window.requestAnimationFrame(() => fitTerminal());
 }
 
 function disposeTerminal() {
@@ -1160,6 +1170,7 @@ async function scrollToBottom() {
 .serial-monitor-shell {
   height: 100%;
   max-height: 100%;
+  min-width: 0;
 }
 
 .tool-button,
@@ -1281,26 +1292,36 @@ async function scrollToBottom() {
   background: var(--vscode-terminal-background, var(--vscode-background));
   color: var(--vscode-terminal-foreground, var(--vscode-foreground));
   outline: none;
+  min-width: 0;
 }
 
 .xterm-host {
+  width: 100%;
   height: 100%;
   min-height: 0;
+  min-width: 0;
   overflow: hidden;
 }
 
 .xterm-host :deep(.xterm) {
   box-sizing: border-box;
+  width: 100%;
   height: 100%;
   padding: 8px 10px;
 }
 
 .xterm-host :deep(.xterm-screen) {
+  width: 100%;
   min-height: 100%;
 }
 
 .xterm-host :deep(.xterm-viewport) {
   background: transparent;
+}
+
+.xterm-host :deep(.xterm-helpers),
+.xterm-host :deep(.xterm-helper-textarea) {
+  max-width: 100%;
 }
 
 .send-input {


### PR DESCRIPTION
## Summary
Fix xterm CSS loading and terminal layout in serial monitor.

- Include xterm.css in main webview assets
- Add window resize handler for xterm re-fit
- Fix xterm container overflow with min-width/width constraints
- Use `h-full` for standalone route layout

## Test
```
yarn run compile
yarn run build:webview
```